### PR TITLE
Add AllowLocalhost config parameter to default constructor

### DIFF
--- a/spnego-auth/pom.xml
+++ b/spnego-auth/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>de.ctrlaltdel</groupId>
   <artifactId>spnego-auth</artifactId>
-  <version>1.0</version>
+  <version>1.0.1</version>
   <packaging>jar</packaging>
 
   <dependencies>

--- a/spnego-auth/src/main/java/net/sourceforge/spnego/SpnegoAuthenticator.java
+++ b/spnego-auth/src/main/java/net/sourceforge/spnego/SpnegoAuthenticator.java
@@ -146,6 +146,8 @@ public final class SpnegoAuthenticator {
         this.serverCredentials = SpnegoProvider.getServerCredential(this.loginContext.getSubject());
 
         this.serverPrincipal = new KerberosPrincipal(this.serverCredentials.getName().toString());
+
+        this.allowLocalhost = Boolean.getBoolean(Constants.ALLOW_LOCALHOST);
     }
 
     /**


### PR DESCRIPTION
making it possible to configure this parameter when the Authenticator is instantiated e.g. ad WildFly authentication mechanism.